### PR TITLE
Adds zipkin.http.compressionEnabled flag for gzipping span json

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Here are the flags that apply to Http:
 Flag | Default | Description
 --- | --- | ---
 zipkin.http.host | localhost:9411 | Zipkin server listening on http; also used as the Host header
+zipkin.http.compressionEnabled | true | True implies that spans will be gzipped before transport
 
 Ex. Here's how to configure the Zipkin server with a system property:
 ```bash

--- a/core/src/main/java/zipkin/finagle/ZipkinTracer.java
+++ b/core/src/main/java/zipkin/finagle/ZipkinTracer.java
@@ -78,7 +78,7 @@ public class ZipkinTracer extends SamplingTracer implements Closable {
   }
 
   protected interface Config {
-    /** How much data to collect. Default sample rate 0.1%. Max is 1, min 0. */
+    /** How much data to collect. Default sample rate 0.001 (0.1%). Max is 1, min 0. */
     float initialSampleRate();
   }
 

--- a/http/src/main/java/zipkin/finagle/http/HttpZipkinTracer.java
+++ b/http/src/main/java/zipkin/finagle/http/HttpZipkinTracer.java
@@ -39,7 +39,7 @@ public final class HttpZipkinTracer extends ZipkinTracer {
   }
 
   HttpZipkinTracer(Config config, StatsReceiver stats) {
-    this(new HttpSpanConsumer(config.host()), config, stats);
+    this(new HttpSpanConsumer(config), config, stats);
   }
 
   private HttpZipkinTracer(HttpSpanConsumer http, Config config, StatsReceiver stats) {
@@ -83,6 +83,7 @@ public final class HttpZipkinTracer extends ZipkinTracer {
     public static Builder builder() {
       return new AutoValue_HttpZipkinTracer_Config.Builder()
           .host(HttpZipkinTracerFlags.host())
+          .compressionEnabled(HttpZipkinTracerFlags.compressionEnabled())
           .initialSampleRate(ZipkinTracerFlags.initialSampleRate());
     }
 
@@ -92,13 +93,18 @@ public final class HttpZipkinTracer extends ZipkinTracer {
 
     abstract String host();
 
+    abstract boolean compressionEnabled();
+
     @AutoValue.Builder
     public interface Builder {
 
       /** Zipkin server listening on http; also used as the Host header. */
       Builder host(String host);
 
-      /** How much data to collect. Default sample rate 0.1%. Max is 1, min 0. */
+      /** True implies that spans will be gzipped before transport. Defaults to true. */
+      Builder compressionEnabled(boolean compressSpans);
+
+      /** @see ZipkinTracer.Config#initialSampleRate() */
       Builder initialSampleRate(float initialSampleRate);
 
       Config build();

--- a/http/src/main/java/zipkin/finagle/http/HttpZipkinTracerFlags.java
+++ b/http/src/main/java/zipkin/finagle/http/HttpZipkinTracerFlags.java
@@ -44,5 +44,28 @@ public final class HttpZipkinTracerFlags {
       return host$.MODULE$.getGlobalFlag();
     }
   }
+
+  static boolean compressionEnabled() {
+    return compressionEnabled$.MODULE$.apply();
+  }
+
+  public static final class compressionEnabled$ extends GlobalFlag<Boolean> {
+    public static final compressionEnabled$ MODULE$ = new compressionEnabled$();
+
+    private compressionEnabled$() {
+      super(true, "True implies that spans will be gzipped before transport",
+          Flaggable$.MODULE$.ofJavaBoolean());
+    }
+
+    @Override public String name() {
+      return "zipkin.http.compressionEnabled";
+    }
+  }
+
+  public static final class compressionEnabled {
+    public static Flag<?> getGlobalFlag() {
+      return compressionEnabled$.MODULE$.getGlobalFlag();
+    }
+  }
 }
 

--- a/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerFlagsTest.java
+++ b/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerFlagsTest.java
@@ -25,6 +25,8 @@ public class HttpZipkinTracerFlagsTest {
   public void flagNamespace() {
     assertThat(HttpZipkinTracerFlags.host.getGlobalFlag().name())
         .isEqualTo("zipkin.http.host");
+    assertThat(HttpZipkinTracerFlags.compressionEnabled.getGlobalFlag().name())
+        .isEqualTo("zipkin.http.compressionEnabled");
   }
 
   @Test
@@ -32,7 +34,8 @@ public class HttpZipkinTracerFlagsTest {
     assertThat(
         asJavaCollection(GlobalFlag$.MODULE$.getAll(HttpZipkinTracerFlags.class.getClassLoader())))
         .containsOnlyOnce(
-            HttpZipkinTracerFlags.host.getGlobalFlag()
+            HttpZipkinTracerFlags.host.getGlobalFlag(),
+            HttpZipkinTracerFlags.compressionEnabled.getGlobalFlag()
         );
   }
 }

--- a/kafka/src/main/java/zipkin/finagle/kafka/KafkaZipkinTracer.java
+++ b/kafka/src/main/java/zipkin/finagle/kafka/KafkaZipkinTracer.java
@@ -127,7 +127,7 @@ public final class KafkaZipkinTracer extends ZipkinTracer {
       /** Sets kafka-topic for zipkin to report to. Default topic zipkin. */
       Builder topic(String topic);
 
-      /** How much data to collect. Default sample rate 0.1%. Max is 1, min 0. */
+      /** @see ZipkinTracer.Config#initialSampleRate() */
       Builder initialSampleRate(float initialSampleRate);
 
       Config build();


### PR DESCRIPTION
compressionEnabled is a commodity feature on zipkin tracers that use
the http api. This adds a flag to disable it.