### PR TITLE
Switches zipkin.http.host to a Finagle Name; Adds zipkin.http.hostHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Here are the flags that apply to Http:
 
 Flag | Default | Description
 --- | --- | ---
-zipkin.http.host | localhost:9411 | Zipkin server listening on http; also used as the Host header
+zipkin.http.host | localhost:9411 | The network location of the Zipkin http service. See http://twitter.github.io/finagle/guide/Names.html
+zipkin.http.hostHeader | zipkin | The Host header used when sending spans to Zipkin
 zipkin.http.compressionEnabled | true | True implies that spans will be gzipped before transport
 
 Ex. Here's how to configure the Zipkin server with a system property:

--- a/http/src/main/java/zipkin/finagle/http/HttpZipkinTracerFlags.java
+++ b/http/src/main/java/zipkin/finagle/http/HttpZipkinTracerFlags.java
@@ -30,7 +30,8 @@ public final class HttpZipkinTracerFlags {
     public static final host$ MODULE$ = new host$();
 
     private host$() {
-      super("localhost:9411", "Zipkin server listening on http; also used as the Host header",
+      super("localhost:9411",
+          "The network location of the Zipkin http service. See http://twitter.github.io/finagle/guide/Names.html",
           Flaggable$.MODULE$.ofString());
     }
 
@@ -42,6 +43,29 @@ public final class HttpZipkinTracerFlags {
   public static final class host {
     public static Flag<?> getGlobalFlag() {
       return host$.MODULE$.getGlobalFlag();
+    }
+  }
+
+  static String hostHeader() {
+    return hostHeader$.MODULE$.apply();
+  }
+
+  public static final class hostHeader$ extends GlobalFlag<String> {
+    public static final hostHeader$ MODULE$ = new hostHeader$();
+
+    private hostHeader$() {
+      super("zipkin", "The Host header used when sending spans to Zipkin",
+          Flaggable$.MODULE$.ofString());
+    }
+
+    @Override public String name() {
+      return "zipkin.http.hostHeader";
+    }
+  }
+
+  public static final class hostHeader {
+    public static Flag<?> getGlobalFlag() {
+      return hostHeader$.MODULE$.getGlobalFlag();
     }
   }
 

--- a/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerFlagsTest.java
+++ b/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerFlagsTest.java
@@ -25,6 +25,8 @@ public class HttpZipkinTracerFlagsTest {
   public void flagNamespace() {
     assertThat(HttpZipkinTracerFlags.host.getGlobalFlag().name())
         .isEqualTo("zipkin.http.host");
+    assertThat(HttpZipkinTracerFlags.hostHeader.getGlobalFlag().name())
+        .isEqualTo("zipkin.http.hostHeader");
     assertThat(HttpZipkinTracerFlags.compressionEnabled.getGlobalFlag().name())
         .isEqualTo("zipkin.http.compressionEnabled");
   }
@@ -35,6 +37,7 @@ public class HttpZipkinTracerFlagsTest {
         asJavaCollection(GlobalFlag$.MODULE$.getAll(HttpZipkinTracerFlags.class.getClassLoader())))
         .containsOnlyOnce(
             HttpZipkinTracerFlags.host.getGlobalFlag(),
+            HttpZipkinTracerFlags.hostHeader.getGlobalFlag(),
             HttpZipkinTracerFlags.compressionEnabled.getGlobalFlag()
         );
   }


### PR DESCRIPTION
By using a Finagle name, "zipkin.http.host" can be multiple addresses
or even a logical path.

This decouples the host header value as "zipkin.http.hostHeader" as now
the two are unlikely to be the same.

Fixes #7
See http://twitter.github.io/finagle/guide/Names.html