### PR TITLE
Switches to AsyncReporter and adds metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,20 @@ Tracer tracer = HttpZipkinTracer.create(config,
     // print stats about zipkin to the console
     new JavaLoggerStatsReceiver(Logger.getAnonymousLogger()));
 ```
+
+## Metrics
+
+The following metrics are reported under a transport-specific category
+to the configured `StatsReceiver`. For example, if using kafka, they are
+reported relative to "zipkin.kafka".
+
+Metric | Description
+--- | ---
+spans | the count of spans recorded by the tracer
+span_bytes | the count of encoded span bytes recorded by the tracer
+spans_dropped | the count of spans dropped for any reason. For example, failure queueing or sending.
+messages | the count of messages sent to zipkin. Ex POST requests or Kafka messages.
+message_bytes | the count of encoded message bytes sent. This includes encoding overhead and excludes compression.
+messages_dropped/exception_class_name+ | count of messages dropped broken down by cause.
+span_queue_size | last count of spans in the pending queue
+span_queue_bytes | last count of encoded span bytes in the pending queue

--- a/core/src/main/java/zipkin/finagle/ReporterMetricsAdapter.java
+++ b/core/src/main/java/zipkin/finagle/ReporterMetricsAdapter.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.finagle;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import com.twitter.finagle.stats.Counter;
+import com.twitter.finagle.stats.StatsReceiver;
+import com.twitter.finagle.stats.StatsReceivers;
+import com.twitter.util.Throwables;
+import java.util.concurrent.Callable;
+import scala.collection.Iterator;
+import scala.collection.Seq;
+import scala.collection.Traversable;
+import zipkin.reporter.ReporterMetrics;
+
+final class ReporterMetricsAdapter implements ReporterMetrics {
+
+  final Counter spans;
+  final Counter spansDropped;
+  final Counter spanBytes;
+  final Counter messages;
+  final Counter messageBytes;
+  final StatsReceiver messagesDropped;
+  final AtomicDouble spanQueueSize;
+  final AtomicDouble spanQueueBytes;
+
+  ReporterMetricsAdapter(StatsReceiver stats) {
+    this.spans = stats.counter0("spans");
+    this.spanBytes = stats.counter0("span_bytes");
+    this.spansDropped = stats.counter0("spans_dropped");
+    this.messages = stats.counter0("messages");
+    this.messageBytes = stats.counter0("message_bytes");
+    this.messagesDropped = stats.scope("messages_dropped");
+    this.spanQueueSize = gaugeFor(stats, "span_queue_size");
+    this.spanQueueBytes = gaugeFor(stats, "span_queue_bytes");
+  }
+
+  @Override public void incrementMessages() {
+    messages.incr();
+  }
+
+  @Override public void incrementMessagesDropped(Throwable cause) {
+    Seq<Traversable<String>> paths = Throwables.mkString(cause).inits().toSeq();
+    for (Iterator<Traversable<String>> i = paths.iterator(); i.hasNext();) {
+      messagesDropped.counter(i.next().toSeq()).incr();
+    }
+  }
+
+  @Override public void incrementSpans(int i) {
+    spans.incr(i);
+  }
+
+  @Override public void incrementSpanBytes(int i) {
+    spanBytes.incr(i);
+  }
+
+  @Override public void incrementMessageBytes(int i) {
+    messageBytes.incr(i);
+  }
+
+  @Override public void incrementSpansDropped(int i) {
+    spansDropped.incr(i);
+  }
+
+  @Override public void updateQueuedSpans(int i) {
+    spanQueueSize.set(i);
+  }
+
+  @Override public void updateQueuedBytes(int i) {
+    spanQueueBytes.set(i);
+  }
+
+  static AtomicDouble gaugeFor(StatsReceiver stats, String scope) {
+    final AtomicDouble result = new AtomicDouble();
+    StatsReceivers.addGauge(stats, new Callable<Float>() {
+      @Override public Float call() throws Exception {
+        return result.floatValue();
+      }
+    }, scope);
+    return result;
+  }
+}

--- a/core/src/test/java/zipkin/finagle/ZipkinTracerIntegrationTest.java
+++ b/core/src/test/java/zipkin/finagle/ZipkinTracerIntegrationTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.finagle;
+
+import com.twitter.finagle.stats.InMemoryStatsReceiver;
+import com.twitter.finagle.tracing.Annotation.ClientRecv;
+import com.twitter.finagle.tracing.Annotation.ClientSend;
+import com.twitter.finagle.tracing.Annotation.Rpc;
+import com.twitter.finagle.tracing.Annotation.ServiceName;
+import com.twitter.finagle.tracing.Record;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Span;
+
+import static com.twitter.util.Time.fromMilliseconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static scala.Option.empty;
+import static scala.collection.JavaConversions.mapAsJavaMap;
+import static zipkin.finagle.FinagleTestObjects.TODAY;
+import static zipkin.finagle.FinagleTestObjects.child;
+import static zipkin.finagle.FinagleTestObjects.root;
+import static zipkin.finagle.FinagleTestObjects.seq;
+
+public abstract class ZipkinTracerIntegrationTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  protected InMemoryStatsReceiver stats = new InMemoryStatsReceiver();
+  protected ZipkinTracer tracer;
+
+  @After
+  public void closeTracer() throws Exception {
+    tracer.close();
+  }
+
+  @Before
+  public void createTracer() {
+    tracer = newTracer();
+  }
+
+  protected abstract ZipkinTracer newTracer();
+
+  protected abstract List<List<Span>> getTraces() throws Exception;
+
+  @Test public void multipleSpansGoIntoSameMessage() throws Exception {
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+
+    tracer.record(new Record(child, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(child, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(child, fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(child, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+
+    Thread.sleep(2000); // the AsyncReporter thread has a default interval of 1s
+
+    assertThat(mapAsJavaMap(stats.counters())).containsExactly(
+        entry(seq("span_bytes"), 341),
+        entry(seq("spans"), 2),
+        entry(seq("message_bytes"), 346),
+        entry(seq("messages"), 1)
+    );
+  }
+}

--- a/kafka/src/main/java/zipkin/finagle/kafka/KafkaZipkinTracer.java
+++ b/kafka/src/main/java/zipkin/finagle/kafka/KafkaZipkinTracer.java
@@ -46,7 +46,7 @@ public final class KafkaZipkinTracer extends ZipkinTracer {
         .build(), config, stats);
   }
 
-  private KafkaZipkinTracer(KafkaSender kafka, Config config, StatsReceiver stats) {
+  KafkaZipkinTracer(KafkaSender kafka, Config config, StatsReceiver stats) {
     super(kafka, config, stats);
     this.kafka = kafka;
   }

--- a/kafka/src/test/java/zipkin/finagle/kafka/KafkaZipkinTracerIntegrationTest.java
+++ b/kafka/src/test/java/zipkin/finagle/kafka/KafkaZipkinTracerIntegrationTest.java
@@ -21,25 +21,32 @@ import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Record;
 import com.twitter.util.Duration;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import kafka.serializer.DefaultDecoder;
-import org.junit.Ignore;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import scala.Option;
 import zipkin.Codec;
 import zipkin.Span;
 import zipkin.finagle.ZipkinTracer;
-import zipkin.finagle.ZipkinTracerTest;
+import zipkin.finagle.ZipkinTracerIntegrationTest;
 import zipkin.finagle.kafka.KafkaZipkinTracer.Config;
+import zipkin.reporter.kafka08.KafkaSender;
 
 import static com.twitter.util.Time.fromMilliseconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static scala.collection.JavaConversions.mapAsJavaMap;
 import static zipkin.finagle.FinagleTestObjects.TODAY;
 import static zipkin.finagle.FinagleTestObjects.root;
+import static zipkin.finagle.FinagleTestObjects.seq;
 
-public class KafkaZipkinTracerTest extends ZipkinTracerTest {
+public class KafkaZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest {
 
   final Option<Duration> none = Option.empty(); // avoid having to force generics
   @Rule
@@ -64,13 +71,35 @@ public class KafkaZipkinTracerTest extends ZipkinTracerTest {
     }
   }
 
-  @Ignore @Test(timeout = 1000) // TODO: https://github.com/openzipkin/zipkin-finagle/issues/4
+  @Test
   public void whenKafkaIsDown() throws Exception {
     kafka.shutdownKafka();
+
+    // Make a new tracer that fails faster than 60 seconds
+    tracer.close();
+    Map<String, String> overrides = new LinkedHashMap<>();
+    overrides.put(ProducerConfig.METADATA_FETCH_TIMEOUT_CONFIG, "100");
+    tracer = new KafkaZipkinTracer(KafkaSender.builder()
+        .bootstrapServers(config.bootstrapServers())
+        .topic(config.topic())
+        .overrides(overrides)
+        .build(), config, stats);
 
     tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), none));
     tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), none));
     tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), none));
     tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), none));
+
+    Thread.sleep(1500); // wait for kafka request attempt to go through
+
+    assertThat(mapAsJavaMap(stats.counters())).containsOnly(
+        entry(seq("spans"), 1),
+        entry(seq("span_bytes"), 165),
+        entry(seq("spans_dropped"), 1),
+        entry(seq("messages"), 1),
+        entry(seq("message_bytes"), 170),
+        entry(seq("messages_dropped"), 1),
+        entry(seq("messages_dropped", "org.apache.kafka.common.errors.TimeoutException"), 1)
+    );
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <!-- version numbers that are used more than once -->
     <scala.binary.version>2.11</scala.binary.version>
     <finagle.version>6.38.0</finagle.version>
-    <zipkin-reporter.version>0.4.3</zipkin-reporter.version>
+    <zipkin-reporter.version>0.5.0</zipkin-reporter.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
The following metrics are reported under a transport-specific category
to the configured `StatsReceiver`. For example, if using kafka, they are
reported relative to "zipkin.kafka".

Metric | Description
--- | ---
spans | the count of spans recorded by the tracer
span_bytes | the count of encoded span bytes recorded by the tracer
spans_dropped | the count of spans dropped for any reason. For example, failure queueing or sending.
messages | the count of messages sent to zipkin. Ex POST requests or Kafka messages.
message_bytes | the count of encoded message bytes sent. This includes encoding overhead and excludes compression.
messages_dropped/exception_class_name+ | count of messages dropped broken down by cause.
span_queue_size | last count of spans in the pending queue
span_queue_bytes | last count of encoded span bytes in the pending queue