### PR TITLE
Changes to build scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Integration between Finagle tracing to Zipkin transports including http, kafka and scribe.
 
 ## Quick start
-Finagle will use a tracer that it detects in the classpath. For example, depending on `io.zipkin.finagle:zipkin-finagle-http_2.11` will send to Zipkin over Http.
+Finagle will use a tracer that it detects in the classpath. For example, depending on `io.zipkin.finagle:zipkin-finagle-http_2.12` will send to Zipkin over Http.
 
 You can look at the [example](https://github.com/openzipkin/zipkin-finagle-example) for this in use.
 
@@ -46,7 +46,7 @@ Flag | Default | Description
 zipkin.initialSampleRate | 0.001 (0.1%) | Percentage of traces to sample (report to zipkin) in the range [0.0 - 1.0]
 
 ### Http Configuration
-Adding `io.zipkin.finagle:zipkin-finagle-http_2.11` to your classpath will configure Finagle
+Adding `io.zipkin.finagle:zipkin-finagle-http_2.12` to your classpath will configure Finagle
 to report trace data to a Zipkin server via HTTP.
 
 Here are the flags that apply to Http:
@@ -63,7 +63,7 @@ $ java -Dzipkin.http.host=192.168.99.100:9411 ...
 ```
 
 ### Kafka Configuration
-Adding `io.zipkin.finagle:zipkin-finagle-kafka_2.11` to your classpath will configure Finagle
+Adding `io.zipkin.finagle:zipkin-finagle-kafka_2.12` to your classpath will configure Finagle
 to report trace data to a Kafka topic. The minimum Kafka server version is 0.8.2.2
 
 Here are the flags that apply to Kafka:
@@ -79,7 +79,7 @@ $ java -Dzipkin.kafka.bootstrapServers=192.168.99.100 ...
 ```
 
 ### Scribe Configuration
-Adding `io.zipkin.finagle:zipkin-finagle-scribe_2.11` to your classpath will configure Finagle
+Adding `io.zipkin.finagle:zipkin-finagle-scribe_2.12` to your classpath will configure Finagle
 to report trace data to the zipkin category of Scribe.
 
 Here are the flags that apply to Scribe:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,11 +19,11 @@
 
   <parent>
     <groupId>io.zipkin.finagle</groupId>
-    <artifactId>zipkin-finagle-parent_2.11</artifactId>
-    <version>0.3.7-SNAPSHOT</version>
+    <artifactId>zipkin-finagle-parent_2.12</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-finagle_2.11</artifactId>
+  <artifactId>zipkin-finagle_2.12</artifactId>
   <name>Zipkin Finagle: Core</name>
 
   <properties>

--- a/core/src/test/java/zipkin/finagle/SpanRecorderTest.java
+++ b/core/src/test/java/zipkin/finagle/SpanRecorderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import zipkin.Span;
 
-import static com.twitter.util.Time.fromMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static scala.Option.empty;
@@ -98,7 +97,7 @@ public class SpanRecorderTest {
 
   @Test public void incrementsCounterWhenUnexpected_binaryAnnotation() throws Exception {
     recorder.record(
-        new Record(root, fromMilliseconds(TODAY),
+        new Record(root, Time.fromMilliseconds(TODAY),
             new Annotation.BinaryAnnotation("web", new Date()), empty())
     );
 
@@ -114,7 +113,7 @@ public class SpanRecorderTest {
 
   @Test public void incrementsCounterWhenUnexpected_annotation() throws Exception {
     recorder.record(
-        new Record(root, fromMilliseconds(TODAY), new FancyAnnotation(), empty())
+        new Record(root, Time.fromMilliseconds(TODAY), new FancyAnnotation(), empty())
     );
 
     assertThat(mapAsJavaMap(stats.counters())).containsExactly(

--- a/core/src/test/java/zipkin/finagle/ZipkinTracerIntegrationTest.java
+++ b/core/src/test/java/zipkin/finagle/ZipkinTracerIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import com.twitter.finagle.tracing.Annotation.ClientSend;
 import com.twitter.finagle.tracing.Annotation.Rpc;
 import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Record;
+import com.twitter.util.Time;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +33,6 @@ import zipkin.Span;
 import zipkin.reporter.Encoder;
 import zipkin.reporter.Encoding;
 
-import static com.twitter.util.Time.fromMilliseconds;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -70,15 +70,15 @@ public abstract class ZipkinTracerIntegrationTest {
   }
 
   @Test public void multipleSpansGoIntoSameMessage() throws Exception {
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
 
-    tracer.record(new Record(child, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(child, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(child, fromMilliseconds(TODAY), new ClientSend(), empty()));
-    tracer.record(new Record(child, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+    tracer.record(new Record(child, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(child, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(child, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(child, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
 
     Thread.sleep(2000); // the AsyncReporter thread has a default interval of 1s
 

--- a/core/src/test/java/zipkin/finagle/ZipkinTracerTest.java
+++ b/core/src/test/java/zipkin/finagle/ZipkinTracerTest.java
@@ -19,6 +19,7 @@ import com.twitter.finagle.tracing.Annotation.ClientSend;
 import com.twitter.finagle.tracing.Annotation.Rpc;
 import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Record;
+import com.twitter.util.Time;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -31,7 +32,6 @@ import zipkin.Span;
 import zipkin.reporter.AsyncReporter;
 import zipkin.reporter.Sender;
 
-import static com.twitter.util.Time.fromMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static scala.Option.empty;
@@ -63,9 +63,9 @@ public class ZipkinTracerTest {
   }
 
   @Test public void unfinishedSpansArentImplicitlyReported() throws Exception {
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
 
     tracer.reporter.flush();
 
@@ -73,12 +73,12 @@ public class ZipkinTracerTest {
   }
 
   @Test public void finishedSpansAreImplicitlyReported() throws Exception {
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
 
     // client receive reports the span
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
 
     tracer.reporter.flush();
 
@@ -90,10 +90,10 @@ public class ZipkinTracerTest {
 
   @Test
   public void reportIncrementsAcceptedMetrics() throws Exception {
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
 
     tracer.reporter.flush();
 
@@ -112,10 +112,10 @@ public class ZipkinTracerTest {
       throw new IllegalStateException(new NullPointerException());
     }));
 
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), empty()));
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), empty()));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), empty()));
 
     tracer.reporter.flush();
 

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -19,11 +19,11 @@
 
   <parent>
     <groupId>io.zipkin.finagle</groupId>
-    <artifactId>zipkin-finagle-parent_2.11</artifactId>
-    <version>0.3.7-SNAPSHOT</version>
+    <artifactId>zipkin-finagle-parent_2.12</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-finagle-http_2.11</artifactId>
+  <artifactId>zipkin-finagle-http_2.12</artifactId>
   <name>Zipkin Finagle: Http</name>
 
   <properties>

--- a/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerIntegrationTest.java
+++ b/http/src/test/java/zipkin/finagle/http/HttpZipkinTracerIntegrationTest.java
@@ -19,6 +19,7 @@ import com.twitter.finagle.tracing.Annotation.Rpc;
 import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Record;
 import com.twitter.util.Duration;
+import com.twitter.util.Time;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +34,6 @@ import zipkin.finagle.ZipkinTracerIntegrationTest;
 import zipkin.finagle.http.HttpZipkinTracer.Config;
 import zipkin.junit.ZipkinRule;
 
-import static com.twitter.util.Time.fromMilliseconds;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -63,10 +63,10 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
     config = config.toBuilder().host("127.0.0.1:65535").build();
     createTracer();
 
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), none));
 
     Thread.sleep(1500); // wait for http request attempt to go through
 
@@ -90,10 +90,10 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
 
     // create instructions to create a complete RPC span
     List<Record> records = asList(
-        new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), none),
-        new Record(root, fromMilliseconds(TODAY), new Rpc("get"), none),
-        new Record(root, fromMilliseconds(TODAY), new ClientSend(), none),
-        new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), none)
+        new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), none),
+        new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), none),
+        new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), none),
+        new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), none)
     );
 
     MockWebServer server = new MockWebServer();

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -19,11 +19,11 @@
 
   <parent>
     <groupId>io.zipkin.finagle</groupId>
-    <artifactId>zipkin-finagle-parent_2.11</artifactId>
-    <version>0.3.7-SNAPSHOT</version>
+    <artifactId>zipkin-finagle-parent_2.12</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-finagle-kafka_2.11</artifactId>
+  <artifactId>zipkin-finagle-kafka_2.12</artifactId>
   <name>Zipkin Finagle: Kafka</name>
 
   <properties>
@@ -49,12 +49,46 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Fix a whole bunch of dependency versions until we use testcontainers to fix classpath -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>0.10.2.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>3.2.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>0.10.2.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>com.github.charithe</groupId>
       <artifactId>kafka-junit</artifactId>
-      <!-- pinned to 0.8.2.2 -->
-      <version>1.7</version>
+      <!-- pinned to 0.10.2.0 -->
+      <version>3.0.3</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka_2.11</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.finagle</groupId>
-  <artifactId>zipkin-finagle-parent_2.11</artifactId>
-  <version>0.3.7-SNAPSHOT</version>
+  <artifactId>zipkin-finagle-parent_2.12</artifactId>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -34,8 +34,8 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.7</main.java.version>
-    <main.signature.artifact>java17</main.signature.artifact>
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
 
     <!-- default bytecode version for src/test -->
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -44,7 +44,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- version numbers that are used more than once -->
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <finagle.version>6.44.0</finagle.version>
     <zipkin-reporter.version>0.7.0</zipkin-reporter.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>

--- a/scribe/pom.xml
+++ b/scribe/pom.xml
@@ -19,11 +19,11 @@
 
   <parent>
     <groupId>io.zipkin.finagle</groupId>
-    <artifactId>zipkin-finagle-parent_2.11</artifactId>
-    <version>0.3.7-SNAPSHOT</version>
+    <artifactId>zipkin-finagle-parent_2.12</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>zipkin-finagle-scribe_2.11</artifactId>
+  <artifactId>zipkin-finagle-scribe_2.12</artifactId>
   <name>Zipkin Finagle: Scribe</name>
 
   <properties>

--- a/scribe/src/test/java/zipkin/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
+++ b/scribe/src/test/java/zipkin/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
@@ -19,6 +19,7 @@ import com.twitter.finagle.tracing.Annotation.Rpc;
 import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Record;
 import com.twitter.util.Duration;
+import com.twitter.util.Time;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -34,7 +35,6 @@ import zipkin.reporter.libthrift.InternalScribeCodec;
 import zipkin.storage.InMemoryStorage;
 import zipkin.storage.QueryRequest;
 
-import static com.twitter.util.Time.fromMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static scala.collection.JavaConversions.mapAsJavaMap;
@@ -81,10 +81,10 @@ public class ScribeZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTe
     config = config.toBuilder().host("127.0.0.1:65535").build();
     createTracer();
 
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY), new ClientSend(), none));
-    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), new ClientRecv(), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ClientSend(), none));
+    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), new ClientRecv(), none));
 
     Thread.sleep(1500); // wait for scribe request attempt to go through
 


### PR DESCRIPTION
Only weird thing is testing kafka as the test fixture has to match the
scala version and 0.8x isn't cross-built for 2.12. To work around this,
we fix the test classpath against a new broker.

Fixes #21
Closes #25