### PR TITLE
update finagle to 18.9.0

### DIFF
--- a/core/src/test/java/zipkin2/finagle/ZipkinTracerIntegrationTest.java
+++ b/core/src/test/java/zipkin2/finagle/ZipkinTracerIntegrationTest.java
@@ -112,6 +112,7 @@ public abstract class ZipkinTracerIntegrationTest {
     assertThat(mapAsJavaMap(stats.counters())).containsExactly(
         entry(FinagleTestObjects.seq("span_bytes"), expectedSpanBytes),
         entry(FinagleTestObjects.seq("spans"), 2L),
+        entry(FinagleTestObjects.seq("spans_dropped"), 0L),
         entry(FinagleTestObjects.seq("message_bytes"), expectedMessageSize),
         entry(FinagleTestObjects.seq("messages"), 1L)
     );

--- a/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
+++ b/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
@@ -131,6 +131,7 @@ public class ZipkinTracerTest {
     assertThat(mapAsJavaMap(stats.counters())).containsExactly(
         entry(seq("span_bytes"), 165L),
         entry(seq("spans"), 1L),
+        entry(seq("spans_dropped"),0L),
         entry(seq("message_bytes"), 170L),
         entry(seq("messages"), 1L)
     );

--- a/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
+++ b/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
@@ -83,7 +83,7 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
         entry(FinagleTestObjects.seq("messages_dropped", "com.twitter.finagle.Failure",
             "com.twitter.finagle.ConnectionFailedException",
             "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-            "io.netty.channel.unix.Erros$NativeConnectException"), 1L)
+            "io.netty.channel.unix.Errors$NativeConnectException"), 1L)
     );
   }
 

--- a/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
+++ b/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
@@ -83,7 +83,7 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
         entry(FinagleTestObjects.seq("messages_dropped", "com.twitter.finagle.Failure",
             "com.twitter.finagle.ConnectionFailedException",
             "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-            "java.net.ConnectException"), 1L)
+            "io.netty.channel.unix.Erros$NativeConnectException"), 1L)
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <!-- version numbers that are used more than once -->
     <scala.binary.version>2.12</scala.binary.version>
-    <finagle.version>18.8.0</finagle.version>
+    <finagle.version>18.9.0</finagle.version>
     <zipkin-reporter.version>2.7.8</zipkin-reporter.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>

--- a/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
+++ b/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
@@ -114,7 +114,7 @@ public class ScribeZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTe
                     "com.twitter.finagle.Failure",
                     "com.twitter.finagle.ConnectionFailedException",
                     "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-                    "java.net.ConnectException"),
+                    "io.netty.channel.unix.Errors$NativeConnectException"),
                 1L));
   }
 }


### PR DESCRIPTION
finagle now add a `spans_dropped` value to the output so there were some (very minor) changes to the tests.