### PR TITLE
update to finagle 18.9.1

### DIFF
--- a/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
+++ b/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
@@ -83,7 +83,7 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
         entry(FinagleTestObjects.seq("messages_dropped", "com.twitter.finagle.Failure",
             "com.twitter.finagle.ConnectionFailedException",
             "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-            "io.netty.channel.unix.Errors$NativeConnectException"), 1L)
+            "java.net.ConnectException"), 1L)
     );
   }
 

--- a/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
+++ b/http/src/test/java/zipkin2/finagle/http/HttpZipkinTracerIntegrationTest.java
@@ -83,7 +83,7 @@ public class HttpZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTest
         entry(FinagleTestObjects.seq("messages_dropped", "com.twitter.finagle.Failure",
             "com.twitter.finagle.ConnectionFailedException",
             "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-            "java.net.ConnectException"), 1L)
+            "io.netty.channel.unix.Error$NativeConnectException"), 1L)
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <!-- version numbers that are used more than once -->
     <scala.binary.version>2.12</scala.binary.version>
-    <finagle.version>18.9.0</finagle.version>
+    <finagle.version>18.9.1</finagle.version>
     <zipkin-reporter.version>2.7.8</zipkin-reporter.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>

--- a/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
+++ b/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
@@ -114,7 +114,7 @@ public class ScribeZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTe
                     "com.twitter.finagle.Failure",
                     "com.twitter.finagle.ConnectionFailedException",
                     "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-                    "java.net.ConnectException"),
+                    "io.netty.channel.unix.Error$NativeConnectException"),
                 1L));
   }
 }

--- a/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
+++ b/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
@@ -114,7 +114,7 @@ public class ScribeZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTe
                     "com.twitter.finagle.Failure",
                     "com.twitter.finagle.ConnectionFailedException",
                     "io.netty.channel.AbstractChannel$AnnotatedConnectException",
-                    "io.netty.channel.unix.Errors$NativeConnectException"),
+                    "java.net.ConnectException"),
                 1L));
   }
 }


### PR DESCRIPTION
update tests to handle changed exceptions on collector not available errors