### PR TITLE
Adds flag zipkin.localServiceName to override any annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ client = Http$.MODULE$.client()
               .newService("remotehost:8080");
 ```
 
+### Note on service names
+
+Sometimes labels used in Finagle do not match the intent of the Zipkin service name. If your traces
+or dependency graph looks incorrect, set the flag `zipkin.localServiceName`. This will ignore any of
+the labels set by servers or clients with the consistent value you supply.
+
 ## Configuration
 
 ### Global Flags
@@ -35,14 +41,15 @@ Global flags can either be set by system property, or commandline argument (ex i
 
 Ex the following are equivalent ways to trace every request:
 ```bash
-$ java -Dzipkin.initialSampleRate=1.0 ...
-$ java -cp my-twitter-server.jar -zipkin.initialSampleRate=1.0
+$ java -Dzipkin.localServiceName=favestar  -Dzipkin.initialSampleRate=1.0 ...
+$ java -cp my-twitter-server.jar -zipkin.localServiceName=favestar -zipkin.initialSampleRate=1.0
 ```
 
 Here are the flags that apply to all transports:
 
 Flag | Default | Description
 --- | --- | ---
+zipkin.localServiceName | unknown | Overrides any ServiceName annotation set by Finagle. Controls Span.localEndpoint.serviceName in Zipkin.
 zipkin.initialSampleRate | 0.001 (0.1%) | Percentage of traces to sample (report to zipkin) in the range [0.0 - 1.0]
 
 ### Http Configuration

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ client = Http$.MODULE$.client()
 
 Sometimes labels used in Finagle do not match the intent of the Zipkin service name. If your traces
 or dependency graph looks incorrect, set the flag `zipkin.localServiceName`. This will ignore any of
-the labels set by servers or clients with the consistent value you supply.
+the labels set by servers. In clients, the `ServiceName` recorded by Finagle will be moved to
+`span.remoteEndpoint.serviceName` in Zipkin under the assumption that it was intended to name the
+remote host.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Global flags can either be set by system property, or commandline argument (ex i
 
 Ex the following are equivalent ways to trace every request:
 ```bash
-$ java -Dzipkin.localServiceName=favestar  -Dzipkin.initialSampleRate=1.0 ...
-$ java -cp my-twitter-server.jar -zipkin.localServiceName=favestar -zipkin.initialSampleRate=1.0
+$ java -Dzipkin.localServiceName=favstar  -Dzipkin.initialSampleRate=1.0 ...
+$ java -cp my-twitter-server.jar -zipkin.localServiceName=favstar -zipkin.initialSampleRate=1.0
 ```
 
 Here are the flags that apply to all transports:

--- a/core/src/main/java/zipkin/localServiceName$.java
+++ b/core/src/main/java/zipkin/localServiceName$.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import com.twitter.app.Flag;
+import com.twitter.app.Flaggable;
+import com.twitter.app.JavaGlobalFlag;
+
+public final class localServiceName$ extends JavaGlobalFlag<String> {
+  private localServiceName$() {
+    super("unknown",
+        "The localEndpoint.serviceName to use for all spans sent to Zipkin", Flaggable.ofString());
+  }
+
+  public static final com.twitter.app.Flag<String> Flag = new localServiceName$();
+
+  public static Flag<?> globalFlagInstance() {
+    return Flag;
+  }
+}

--- a/core/src/main/java/zipkin/localServiceName$.java
+++ b/core/src/main/java/zipkin/localServiceName$.java
@@ -19,8 +19,8 @@ import com.twitter.app.JavaGlobalFlag;
 
 public final class localServiceName$ extends JavaGlobalFlag<String> {
   private localServiceName$() {
-    super("unknown",
-        "The localEndpoint.serviceName to use for all spans sent to Zipkin", Flaggable.ofString());
+    super("unknown", "The localEndpoint.serviceName to use for all spans sent to Zipkin",
+        Flaggable.ofString());
   }
 
   public static final com.twitter.app.Flag<String> Flag = new localServiceName$();

--- a/core/src/main/java/zipkin2/finagle/FinagleSender.java
+++ b/core/src/main/java/zipkin2/finagle/FinagleSender.java
@@ -32,7 +32,7 @@ public abstract class FinagleSender<C extends ZipkinTracer.Config, Req, Rep> ext
   final Service<Req, Rep> client;
 
   /** close is typically called from a different thread */
-  transient boolean closeCalled;
+  volatile boolean closeCalled;
 
   protected FinagleSender(C config) {
     if (config == null) throw new NullPointerException("config == null");
@@ -65,7 +65,7 @@ public abstract class FinagleSender<C extends ZipkinTracer.Config, Req, Rep> ext
   }
 
   public Future<BoxedUnit> closeFuture() {
-    if (closeCalled) return null;
+    if (closeCalled) return Future.Done();
     closeCalled = true;
     return client.close();
   }

--- a/core/src/main/java/zipkin2/finagle/ZipkinTracer.java
+++ b/core/src/main/java/zipkin2/finagle/ZipkinTracer.java
@@ -183,6 +183,18 @@ public class ZipkinTracer extends SamplingTracer implements Closable {
     }
 
     /**
+     * The localEndpoint.serviceName to use for all spans sent to Zipkin.
+     *
+     * <p>Default is to look at the {@link Annotation.ServiceName} annotation. However, as clients
+     * often set this to the destination host, you may with to override this here.
+     */
+    public Builder localServiceName(String localServiceName) {
+      if (localServiceName == null) throw new NullPointerException("localServiceName == null");
+      this.config.localServiceName = localServiceName;
+      return this;
+    }
+
+    /**
      * Percentage of traces to sample (report to zipkin) in the range [0.0 - 1.0].
      *
      * <p>Default is the value of the flag {@code zipkin.initialSampleRate} which if not overridden

--- a/core/src/main/java/zipkin2/finagle/ZipkinTracer.java
+++ b/core/src/main/java/zipkin2/finagle/ZipkinTracer.java
@@ -183,10 +183,14 @@ public class ZipkinTracer extends SamplingTracer implements Closable {
     }
 
     /**
-     * The localEndpoint.serviceName to use for all spans sent to Zipkin.
+     * Lower-case label of the remote node in the service graph, such as "favstar". Avoid names
+     * with variables or unique identifiers embedded.
      *
-     * <p>Default is to look at the {@link Annotation.ServiceName} annotation. However, as clients
-     * often set this to the destination host, you may with to override this here.
+     * <p>When unset, the service name is derived from {@link Annotation.ServiceName} which is
+     * often incorrectly set to the remote service name.
+     *
+     * <p>This is a primary label for trace lookup and aggregation, so it should be intuitive and
+     * consistent. Many use a name from service discovery.
      */
     public Builder localServiceName(String localServiceName) {
       if (localServiceName == null) throw new NullPointerException("localServiceName == null");

--- a/core/src/test/java/zipkin/localServiceNameTest.java
+++ b/core/src/test/java/zipkin/localServiceNameTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin;
+
+import com.twitter.app.Flag;
+import com.twitter.app.GlobalFlag$;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Test;
+import scala.Function0;
+import scala.Option;
+import scala.runtime.AbstractFunction0;
+import scala.runtime.BoxedUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static scala.collection.JavaConverters.asJavaCollection;
+
+public class localServiceNameTest {
+  @After public void resetGlobalFlags() {
+    for (Flag<?> globalFlag: globalFlags()) globalFlag.reset();
+  }
+
+  @Test public void defaultValue() {
+    Option<Flag<?>> flagOption = GlobalFlag$.MODULE$.get("zipkin.localServiceName");
+    assertThat(flagOption.get().apply()).isEqualTo("unknown");
+  }
+
+  @Test public void letOverridesDefault() {
+    final String override = "favstar";
+
+    final AtomicBoolean ran = new AtomicBoolean();
+    Function0<BoxedUnit> fn0 = new AbstractFunction0<BoxedUnit>() {
+      @Override public BoxedUnit apply() {
+        ran.set(true); // used to verify this block is executed.
+        assertThat(localServiceName$.Flag.isDefined()).isTrue();
+        assertThat(localServiceName$.Flag.apply()).isEqualTo(override);
+        return BoxedUnit.UNIT;
+      }
+    };
+    localServiceName$.Flag.let(override, fn0);
+
+    assertThat(ran.get()).isTrue();
+  }
+
+  @Test
+  public void registersGlobal() {
+    assertThat(globalFlags())
+        .extracting(f -> f.name())
+        .containsOnlyOnce("zipkin.localServiceName");
+  }
+
+  Collection<Flag<?>> globalFlags() {
+    return asJavaCollection(GlobalFlag$.MODULE$.getAll(getClass().getClassLoader()));
+  }
+}

--- a/core/src/test/java/zipkin2/finagle/SpanRecorderTest.java
+++ b/core/src/test/java/zipkin2/finagle/SpanRecorderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,7 +52,7 @@ public class SpanRecorderTest {
   public void setRecorder() {
     // Recorder schedules a flusher thread on instantiation. Do this in a Before block so
     // that we can control time.
-    recorder = new SpanRecorder(span -> spansSent.add(span), stats, timer);
+    recorder = new SpanRecorder(span -> spansSent.add(span), stats, timer, "unknown");
   }
 
   /** This is replaying actual events that happened with Finagle's tracer */

--- a/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
+++ b/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
@@ -89,7 +89,7 @@ public class ZipkinTracerTest {
   }
 
   @Test public void configOverridesLocalServiceName_client() throws Exception {
-    tracer = spanReporter("favstar");
+    tracer = tracerWithLocalServiceName("favstar");
 
     recordClientSpan(root);
 
@@ -100,7 +100,7 @@ public class ZipkinTracerTest {
   }
 
   @Test public void configOverridesLocalServiceName_client_combines() throws Exception {
-    tracer = spanReporter("favstar");
+    tracer = tracerWithLocalServiceName("favstar");
 
     tracer.record(new Record(root, fromMilliseconds(TODAY), new Annotation.LocalAddr(
         new InetSocketAddress("1.2.3.3", 443)), empty()));
@@ -117,7 +117,7 @@ public class ZipkinTracerTest {
   }
 
   @Test public void configOverridesLocalServiceName_server() throws Exception {
-    tracer = spanReporter("favstar");
+    tracer = tracerWithLocalServiceName("favstar");
 
     recordServerSpan(root);
 
@@ -209,7 +209,7 @@ public class ZipkinTracerTest {
     ((AsyncReporter) tracer.reporter).flush();
   }
 
-  ZipkinTracer spanReporter(String localServiceName) {
+  ZipkinTracer tracerWithLocalServiceName(String localServiceName) {
     return newTracer(reporterBuilder(spansSent::add)
             .messageMaxBytes(500), // RPC spans are bigger than local ones
         localServiceName);

--- a/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
+++ b/core/src/test/java/zipkin2/finagle/ZipkinTracerTest.java
@@ -14,9 +14,12 @@
 package zipkin2.finagle;
 
 import com.twitter.finagle.stats.InMemoryStatsReceiver;
+import com.twitter.finagle.tracing.Annotation;
 import com.twitter.finagle.tracing.Annotation.ClientRecv$;
 import com.twitter.finagle.tracing.Annotation.ClientSend$;
 import com.twitter.finagle.tracing.Annotation.Rpc;
+import com.twitter.finagle.tracing.Annotation.ServerRecv$;
+import com.twitter.finagle.tracing.Annotation.ServerSend$;
 import com.twitter.finagle.tracing.Annotation.ServiceName;
 import com.twitter.finagle.tracing.Flags$;
 import com.twitter.finagle.tracing.Record;
@@ -24,19 +27,21 @@ import com.twitter.finagle.tracing.SpanId;
 import com.twitter.finagle.tracing.TraceId;
 import com.twitter.finagle.tracing.TraceId$;
 import com.twitter.finagle.tracing.traceId128Bit$;
-import com.twitter.util.Time;
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.Sender;
 
+import static com.twitter.util.Time.fromMilliseconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
@@ -47,40 +52,31 @@ import static zipkin2.finagle.FinagleTestObjects.root;
 import static zipkin2.finagle.FinagleTestObjects.seq;
 
 public class ZipkinTracerTest {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   InMemoryStatsReceiver stats = new InMemoryStatsReceiver();
   BlockingQueue<List<Span>> spansSent = new LinkedBlockingDeque<>();
 
-  ZipkinTracer.Config config = new ZipkinTracer.Config() {
-    @Override public String localServiceName() {
-      return "unknown";
-    }
+  // Initialize with the special keyword unknown which delegates to Annotation.ServiceName otherwise
+  ZipkinTracer tracer = newTracer(reporterBuilder(spansSent::add), "unknown");
 
-    @Override public float initialSampleRate() {
-      return 1.0f;
-    }
-  };
-
-  ZipkinTracer tracer = newTracer(FakeSender.create().onSpans(spansSent::add));
-
-  ZipkinTracer newTracer(Sender sender) {
-    return ZipkinTracer.newBuilder(AsyncReporter.builder(sender)
+  AsyncReporter.Builder reporterBuilder(Consumer<List<Span>> onSpans) {
+    return AsyncReporter.builder(FakeSender.create().onSpans(onSpans))
         .messageTimeout(0, TimeUnit.MILLISECONDS)
-        .messageMaxBytes(176 + 5) // size of a simple span w/ 128-bit trace ID + list overhead
-        .metrics(new ReporterMetricsAdapter(stats))
-<<<<<<< HEAD
-        .build())
-        .initialSampleRate(1.0f)
-        .stats(stats).build();
-=======
-        .build(), config, stats);
->>>>>>> Adds flag zipkin.localServiceName to override any annotations
+        .messageMaxBytes(176 + 5)  // size of a simple span w/ 128-bit trace ID + list overhead
+        .metrics(new ReporterMetricsAdapter(stats));
   }
 
-  @After
-  public void closeTracer() {
+  ZipkinTracer newTracer(AsyncReporter.Builder spanReporter, String localServiceName) {
+    if (tracer != null) tracer.close();
+    return ZipkinTracer.newBuilder(spanReporter.build())
+        .initialSampleRate(1.0f)
+        .localServiceName(localServiceName)
+        .stats(stats)
+        .build();
+  }
+
+  @After public void closeTracer() {
     tracer.close();
   }
 
@@ -92,29 +88,49 @@ public class ZipkinTracerTest {
         .containsExactly("web");
   }
 
-  @Test public void configOverridesLocalServiceName() throws Exception {
-    config = new ZipkinTracer.Config() {
-      @Override public String localServiceName() {
-        return "favstar";
-      }
-
-      @Override public float initialSampleRate() {
-        return 1.0f;
-      }
-    };
-    tracer = newTracer(FakeSender.create().onSpans(spansSent::add));
+  @Test public void configOverridesLocalServiceName_client() throws Exception {
+    tracer = spanReporter("favstar");
 
     recordClientSpan(root);
 
+    // Moves recorded service name to the remote service name
     assertThat(spansSent.take().stream())
-        .flatExtracting(Span::localServiceName)
-        .containsExactly("favstar");
+        .flatExtracting(Span::localServiceName, Span::remoteServiceName)
+        .containsExactly("favstar", "web");
+  }
+
+  @Test public void configOverridesLocalServiceName_client_combines() throws Exception {
+    tracer = spanReporter("favstar");
+
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new Annotation.LocalAddr(
+        new InetSocketAddress("1.2.3.3", 443)), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new Annotation.ServerAddr(
+        new InetSocketAddress("1.2.3.4", 80)), empty()));
+    recordClientSpan(root);
+
+    Span span = spansSent.take().get(0);
+    // Combines the recorded service name with the remote IP and socket info
+    assertThat(span.localEndpoint())
+        .isEqualTo(Endpoint.newBuilder().serviceName("favstar").ip("1.2.3.3").port(443).build());
+    assertThat(span.remoteEndpoint())
+        .isEqualTo(Endpoint.newBuilder().serviceName("web").ip("1.2.3.4").port(80).build());
+  }
+
+  @Test public void configOverridesLocalServiceName_server() throws Exception {
+    tracer = spanReporter("favstar");
+
+    recordServerSpan(root);
+
+    // Doesn't set remote service name
+    assertThat(spansSent.take().stream())
+        .flatExtracting(Span::localServiceName, Span::remoteServiceName)
+        .containsExactly("favstar", null);
   }
 
   @Test public void unfinishedSpansArentImplicitlyReported() throws Exception {
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
 
     flush();
 
@@ -122,18 +138,7 @@ public class ZipkinTracerTest {
   }
 
   @Test public void finishedSpansAreImplicitlyReported() throws Exception {
-<<<<<<< HEAD
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
-
-    // client receive reports the span
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
-
-    flush();
-=======
     recordClientSpan(root);
->>>>>>> Adds flag zipkin.localServiceName to override any annotations
 
     assertThat(spansSent.take().stream())
         .flatExtracting(Span::kind)
@@ -142,7 +147,7 @@ public class ZipkinTracerTest {
 
   /** See {@link traceId128Bit$} */
   @Test public void traceId128Bit() throws Exception {
-      TraceId root = TraceId$.MODULE$.apply(
+    TraceId root = TraceId$.MODULE$.apply(
         SpanId.fromString("0f28590523a46541"),
         empty(),
         SpanId.fromString("0f28590523a46541").get(),
@@ -152,58 +157,34 @@ public class ZipkinTracerTest {
         false
     );
 
-<<<<<<< HEAD
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
-
-    // client receive reports the span
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
-
-    flush();
-=======
     recordClientSpan(root);
->>>>>>> Adds flag zipkin.localServiceName to override any annotations
 
     assertThat(spansSent.take().stream())
         .extracting(Span::traceId)
         .containsExactly("d2f9288a2904503d0f28590523a46541");
   }
 
-  @Test
-<<<<<<< HEAD
-  public void reportIncrementsAcceptedMetrics() {
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
-
-    flush();
-=======
-  public void reportIncrementsAcceptedMetrics() throws Exception {
+  @Test public void reportIncrementsAcceptedMetrics() {
     recordClientSpan(root);
->>>>>>> Adds flag zipkin.localServiceName to override any annotations
 
     assertThat(mapAsJavaMap(stats.counters())).containsExactly(
         entry(seq("span_bytes"), 165L),
         entry(seq("spans"), 1L),
-        entry(seq("spans_dropped"),0L),
+        entry(seq("spans_dropped"), 0L),
         entry(seq("message_bytes"), 170L),
         entry(seq("messages"), 1L)
     );
   }
 
-  @Test
-  public void incrementsDropMetricsOnSendError() {
-    tracer.close();
-    tracer = newTracer(FakeSender.create().onSpans(span -> {
+  @Test public void incrementsDropMetricsOnSendError() {
+    tracer = newTracer(reporterBuilder(span -> {
       throw new IllegalStateException(new NullPointerException());
-    }));
+    }), "unknown");
 
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
-    tracer.record(new Record(root, Time.fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
+    tracer.record(new Record(root, fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
 
     try {
       flush();
@@ -224,19 +205,35 @@ public class ZipkinTracerTest {
     );
   }
 
-<<<<<<< HEAD
   void flush() {
     ((AsyncReporter) tracer.reporter).flush();
-=======
+  }
+
+  ZipkinTracer spanReporter(String localServiceName) {
+    return newTracer(reporterBuilder(spansSent::add)
+            .messageMaxBytes(500), // RPC spans are bigger than local ones
+        localServiceName);
+  }
+
   void recordClientSpan(TraceId traceId) {
-    tracer.record(new Record(traceId, Time.fromMilliseconds(TODAY), new ServiceName("web"), empty()));
-    tracer.record(new Record(traceId, Time.fromMilliseconds(TODAY), new Rpc("get"), empty()));
-    tracer.record(new Record(traceId, Time.fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), ClientSend$.MODULE$, empty()));
 
     // client receive reports the span
-    tracer.record(new Record(traceId, Time.fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY + 1), ClientRecv$.MODULE$, empty()));
 
-    tracer.reporter.flush();
->>>>>>> Adds flag zipkin.localServiceName to override any annotations
+    flush();
+  }
+
+  void recordServerSpan(TraceId traceId) {
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), new ServiceName("web"), empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), new Rpc("get"), empty()));
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY), ServerRecv$.MODULE$, empty()));
+
+    // server send reports the span
+    tracer.record(new Record(traceId, fromMilliseconds(TODAY + 1), ServerSend$.MODULE$, empty()));
+
+    flush();
   }
 }

--- a/kafka/src/test/java/zipkin2/finagle/kafka/KafkaZipkinTracerIntegrationTest.java
+++ b/kafka/src/test/java/zipkin2/finagle/kafka/KafkaZipkinTracerIntegrationTest.java
@@ -59,7 +59,8 @@ public class KafkaZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTes
     super.createTracer();
   }
 
-  @Override protected ZipkinTracer newTracer() {
+  @Override protected ZipkinTracer newTracer(String localServiceName) {
+    config = config.toBuilder().localServiceName(localServiceName).build();
     return new KafkaZipkinTracer(config, stats);
   }
 
@@ -72,8 +73,7 @@ public class KafkaZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTes
         .collect(toList());
   }
 
-  @Test
-  public void whenKafkaIsDown() throws Exception {
+  @Test public void whenKafkaIsDown() throws Exception {
     broker.stop();
 
     // Make a new tracer that fails faster than 60 seconds

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <finagle.version>19.7.0</finagle.version>
     <log4j.version>2.12.0</log4j.version>
     <auto-value.version>1.6.3</auto-value.version>
-    <zipkin-reporter.version>2.9.0</zipkin-reporter.version>
+    <zipkin-reporter.version>2.10.0</zipkin-reporter.version>
 
     <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>

--- a/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
+++ b/scribe/src/test/java/zipkin2/finagle/scribe/ScribeZipkinTracerIntegrationTest.java
@@ -46,37 +46,32 @@ public class ScribeZipkinTracerIntegrationTest extends ZipkinTracerIntegrationTe
   InMemoryStorage storage = InMemoryStorage.newBuilder().build();
   ScribeCollector scribe;
 
-  @Before
-  public void start() {
+  @Before public void start() {
     scribe = ScribeCollector.newBuilder().storage(storage).build();
     scribe.start();
   }
 
-  @After
-  public void close() {
+  @After public void close() {
     scribe.close();
   }
 
   Config config = Config.builder().initialSampleRate(1.0f).host("127.0.0.1:9410").build();
 
-  @Override
-  protected ZipkinTracer newTracer() {
+  @Override protected ZipkinTracer newTracer(String localServiceName) {
+    config = config.toBuilder().localServiceName(localServiceName).build();
     return new ScribeZipkinTracer(config, stats);
   }
 
-  @Override
-  protected List<List<Span>> getTraces() {
+  @Override protected List<List<Span>> getTraces() {
     return storage.getTraces();
   }
 
   /** Scribe can only use thrift */
-  @Override
-  protected SpanBytesEncoder encoder() {
+  @Override protected SpanBytesEncoder encoder() {
     return SpanBytesEncoder.THRIFT;
   }
 
-  @Test
-  public void whenScribeIsDown() throws Exception {
+  @Test public void whenScribeIsDown() throws Exception {
     scribe.close();
 
     tracer.record(new Record(root, Time.fromMilliseconds(TODAY), new ServiceName("web"), none));


### PR DESCRIPTION
This should be used in general and will result in more consistent
trace relationships including the service dependency graph.

Fixes #67