### PR TITLE
issue 109 - log4shell remediation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <!-- version numbers that are used more than once -->
     <finagle.version>21.8.0</finagle.version>
-    <log4j.version>2.14.0</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <auto-value.version>1.7.5</auto-value.version>
     <zipkin.version>2.23.2</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <!-- version numbers that are used more than once -->
     <finagle.version>21.8.0</finagle.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <auto-value.version>1.7.5</auto-value.version>
     <zipkin.version>2.23.2</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>


### PR DESCRIPTION
This PR remediates log4shell by upgrading the log4j dependency to 2.16.0.

Recommend you release a new version of this package so your community is less exposed to log4shell

Closes #109 